### PR TITLE
Move swap options to conf files in sysctl.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ None.
 
 ### Optional
 
-The following variables are set to `False` by default and will not have any effect on your hosts. Setting them to any value other than `False` will update your hosts' sysctl.conf file.
+The following variables are set to `False` by default and will not have any effect on your hosts. Setting them to any value other than `False` will update the corresponding configuration files in your hosts' `/etc/sysctl.d` directory.
 
 * `swapfile_swappiness` [default: `False`]: the swappiness percentage (vm.swappiness) -- the lower it is, the less your system swaps memory pages
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Reload sysctl
-  command: sysctl -p
+  command: sysctl -p /etc/sysctl.d/60-vm.*.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,11 +27,11 @@
   when: swapfile_size != false
 
 - name: Configure vm.swappiness
-  lineinfile: dest=/etc/sysctl.conf line="vm.swappiness = {{ swapfile_swappiness }}" regexp="^vm.swappiness[\s]?=" state=present
+  lineinfile: dest=/etc/sysctl.d/60-vm.swappiness.conf line="vm.swappiness = {{ swapfile_swappiness }}" regexp="^vm.swappiness[\s]?=" state=present create=yes
   notify: Reload sysctl
   when: swapfile_swappiness != false
 
 - name: Configure vm.vfs_cache_pressure
-  lineinfile: dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ swapfile_vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure[\s]?=" state=present
+  lineinfile: dest=/etc/sysctl.d/60-vm.vfs_cache_pressure.conf line="vm.vfs_cache_pressure = {{ swapfile_vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure[\s]?=" state=present  create=yes
   notify: Reload sysctl
   when: swapfile_vfs_cache_pressure != false


### PR DESCRIPTION
Thanks for this Ansible role!

Any interest in implementing the suggestion by j13k [here](https://www.digitalocean.com/community/tutorials/how-to-add-swap-on-ubuntu-14-04?comment=19404)?
Looks smart to me, but I'm new to this stuff.

Here's what appeals to me (quoting j13k at link above):
>My suggestion is to place the new VM settings in this directory, with the benefits being that, as well as the original configuration file remaining intact, the new settings are less likely to be affected by system upgrades. Also, reverting to the default settings should simply a matter of deleting the files.