### PR TITLE
Swap priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ None.
 
 * `swapfile_location` [default: `/swapfile`]: the location of where the swapfile will be created
 
+* `swapfile_priority` [default: `0`]: the priority of swapfile:
+    If you have more than one swap file or swap partition you should consider assigning a priority value (0 to 32767) for each swap area. The system will use swap areas of higher priority before using swap areas of lower priority.
+
 ### Optional
 
 The following variables are set to `False` by default and will not have any effect on your hosts. Setting them to any value other than `False` will update your hosts' sysctl.conf file.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ swapfile_size: 512MB
 swapfile_swappiness: False
 swapfile_vfs_cache_pressure: False
 swapfile_use_dd: False
+swapfile_priority: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,11 +19,11 @@
   when: swapfile_size != false and write_swapfile.changed
 
 - name: Enable swapfile
-  command: swapon {{ swapfile_location }}
+command: swapon -p {{ swapfile_priority }} {{ swapfile_location }}
   when: swapfile_size != false and create_swapfile.changed
 
 - name: Add swapfile to /etc/fstab
-  lineinfile: dest=/etc/fstab line="{{ swapfile_location }}   none    swap    sw    0   0" state=present
+  lineinfile: dest=/etc/fstab line="{{ swapfile_location }}   none    swap    sw,{{ swapfile_priority }}    0   0" state=present
   when: swapfile_size != false
 
 - name: Configure vm.swappiness


### PR DESCRIPTION
According to [Archlinux wiki:](https://wiki.archlinux.org/index.php/Swap#Priority)
If you have more than one swap file or swap partition you should consider assigning a priority value (0 to 32767) for each swap area. The system will use swap areas of higher priority before using swap areas of lower priority.