### PR TITLE
Support older versions of `df` that don't have --output option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   register: swap_stat
 
 - name: Get remaining disk space
-  shell: df . --output=avail | grep -vi avail
+  shell: df --portability . | awk '$4 ~ /[0-9]+/ { print $4 }'
   register: available_space
 - set_fact: available_space={{ available_space.stdout_lines[0] | int }}
 


### PR DESCRIPTION
Older versions of `df` lack support for the `--output` option, which causes this role to fail.  `df` v8.13, for example, which is the currently available version on Ubuntu 12.04.  This change does introduce a dependency on `awk`, which I wish we could do without, but I think awk is at least as prevalent as grep, so it's probably okay.