### PR TITLE
Use swapfile destination to calculate available space

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   register: swap_stat
 
 - name: Get remaining disk space
-  shell: df . --output=avail | grep -vi avail
+  shell: df {{swapfile_location|dirname}} --output=avail | grep -vi avail
   register: available_space
 - set_fact: available_space={{ available_space.stdout_lines[0] | int }}
 


### PR DESCRIPTION
This uses the actual destination of the swapfile instead of the CWD, which could be on a different volume.