### PR TITLE
Fix 'ansible_env' is undefined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,14 +54,14 @@
 - name: Create swapfile
   command: mkswap {{ swapfile_location }}
   environment:
-    PATH: "{{ ansible_env.PATH }}:/usr/local/sbin:/usr/sbin:/sbin"
+    PATH: "{{ (ansible_env|default({})).PATH|default('') }}:/usr/local/sbin:/usr/sbin:/sbin"
   register: create_swapfile
   when: swapfile_size != false and write_swapfile.changed
 
 - name: Enable swapfile
   command: swapon {{ swapfile_location }}
   environment:
-    PATH: "{{ ansible_env.PATH }}:/usr/local/sbin:/usr/sbin:/sbin"
+    PATH: "{{ (ansible_env|default({})).PATH|default('') }}:/usr/local/sbin:/usr/sbin:/sbin"
   when: swapfile_size != false and create_swapfile.changed
 
 - name: Add swapfile to /etc/fstab


### PR DESCRIPTION
Change introduced in kamaln7/ansible-swapfile#9 causes:

    the field 'environment' has an invalid value, which appears to include a variable that is undefined. The error was: 'ansible_env' is undefined

    The error appears to have been in '[...]/kamaln7.swapfile/tasks/main.yml': line 54, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

    - name: Create swapfile
     ^ here

with Ansible 2.2.0 when `gather_facts` is used.

See ansible/ansible#14655 for information. This fixed the problem for me, but I did not try any other Ansible versions or setup. Others have reported issues e.g. with commands in `/usr/bin` with the fix, but `swapon` and `mkswap` are probably usually in one of those paths listed in the task file?